### PR TITLE
Replace unknown function `l` with `console.log`

### DIFF
--- a/examples/markdown/markdown.js
+++ b/examples/markdown/markdown.js
@@ -73,7 +73,7 @@ MarkdownInner {
     })
     let match = parser.grammar.match(block.content)
     if(match.failed()) {
-        l("match failed on block",block)
+        console.log("match failed on block",block)
         block.content = [['plain',block.content]]
     } else {
         block.content = parser.semantics(match).content()


### PR DESCRIPTION
`l` is an undefined function here. I believe the original author had some alias somewhere like `const l = console.log`.